### PR TITLE
Fix issue_id param when new issue

### DIFF
--- a/app/views/issues/_didyoumean_injected.html.erb
+++ b/app/views/issues/_didyoumean_injected.html.erb
@@ -19,4 +19,4 @@
   };
 </script>
 
-<%= javascript_tag "observeIssueSubjectField('#{@project.id}', #{@issue.id or 'null'}, '#{issues_didyoumean_event_type}');" %>
+<%= javascript_tag "observeIssueSubjectField('#{@project.id}', #{@issue.id or '\'\''}, '#{issues_didyoumean_event_type}');" %>


### PR DESCRIPTION
With redmine 2.2.1 when creating a new issue, it defines issue_id param to the 'null' string
search_issues_controller check params[:issue_id].blank?
