### PR TITLE
Call where instead of all

### DIFF
--- a/lib/redmine_didyoumean/searching_by_sql.rb
+++ b/lib/redmine_didyoumean/searching_by_sql.rb
@@ -30,7 +30,7 @@ module RedmineDidYouMean
     end
 
     def only_open_condition
-      valid_statuses = IssueStatus.all(:conditions => ["is_closed <> ?", true]).collect(&:id)
+      valid_statuses = IssueStatus.where("is_closed <> ?", true).collect(&:id)
       @query = @query.where(status_id: valid_statuses)
     end
 


### PR DESCRIPTION
Call the where function instead of the all function because of the ActiveRecord api change.
For Redmine 3.x